### PR TITLE
Implement incremental polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each file is read line by line, and each line is sent as an independent Kafka re
   - A structured `JSON` (`Schema + Struct`)
 - Optional field mapping via `ftp.file.headers`
 - Optional Kafka key based on one or more fields (`ftp.kafka.key.field`)
+- Limit records returned per poll (`ftp.max.records.per.poll`)
 - Moves files to:
   - A staging folder before processing
   - An archive folder after processing
@@ -48,6 +49,7 @@ Each file is read line by line, and each line is sent as an independent Kafka re
     "ftp.file.headers": "type,date,time,code,value",
     "ftp.kafka.key.field": "type+code",
     "ftp.poll.interval.ms": "10000",
+    "ftp.max.records.per.poll": "1000",
     "topic": "ftp-data-topic",
     "tasks.max": "1"
   }

--- a/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceConnector.java
+++ b/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceConnector.java
@@ -29,6 +29,8 @@ public class FtpSourceConnector extends SourceConnector {
         public static final String FTP_FILE_HEADERS = "ftp.file.headers";
         public static final String FTP_KAFKA_KEY_FIELD = "ftp.kafka.key.field";
 
+        public static final String FTP_MAX_RECORDS_PER_POLL = "ftp.max.records.per.poll";
+
         public static final String FTP_POLL_INTERVAL = "ftp.poll.interval.ms";
 
         public static final String TOPIC = "topic";
@@ -95,6 +97,8 @@ public class FtpSourceConnector extends SourceConnector {
                                                 "Field name from headers to be used as Kafka message key")
                                 .define(FTP_POLL_INTERVAL, ConfigDef.Type.INT, 10000, ConfigDef.Importance.LOW,
                                                 "Polling interval in milliseconds")
+                                .define(FTP_MAX_RECORDS_PER_POLL, ConfigDef.Type.INT, 1000, ConfigDef.Importance.LOW,
+                                                "Maximum number of records returned per poll")
                                 .define(TOPIC, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
                                                 "Kafka topic to publish the file data");
         }


### PR DESCRIPTION
## Summary
- limit number of records per poll via `ftp.max.records.per.poll`
- keep open reader between polls so large files are processed incrementally
- add progress logging
- update README with new option
- expand tests for the new incremental logic

## Testing
- `mvn -q test` *(fails: Plugin resolution, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6881309ea4e883308ede804d6cea2580