### PR TITLE
Add remote delete/write operations and summary generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Each file is read line by line, and each line is sent as an independent Kafka re
 
 ## Features
 
-- Supports FTP and SFTP protocols  
+- Supports FTP and SFTP protocols
 - Processes files line-by-line
 - Configurable:
   - File encoding (`ftp.file.encoding`)
@@ -19,11 +19,16 @@ Each file is read line by line, and each line is sent as an independent Kafka re
 - Optional field mapping via `ftp.file.headers`
 - Optional Kafka key based on one or more fields (`ftp.kafka.key.field`)
 - Limit records returned per poll (`ftp.max.records.per.poll`)
-- Moves files to:
-  - A staging folder before processing
-  - An archive folder after processing
-- Archives include a timestamp in filename  
+- Moves files to a staging folder before processing
+- Generates a summary report file in the archive directory after processing and removes the staged copy
+- Summary files include a timestamp in filename
   Format: `yyyyMMdd_HHmmssSSS` (e.g., `WB1_20250408_121045123.txt`)
+
+---
+
+## Requirements
+
+- Build with Java 11 (compatible with Kafka Connect distributions that still run on Java 11)
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 		<slf4j.version>2.0.13</slf4j.version>
 		<junit.version>5.10.0</junit.version>
 		<mockito.version>5.10.0</mockito.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
 		<maven.assembly.version>3.3.0</maven.assembly.version>
 		<maven.shade.version>3.4.1</maven.shade.version>
 		<maven.surefire.version>3.2.5</maven.surefire.version>

--- a/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpRemoteClient.java
+++ b/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpRemoteClient.java
@@ -5,8 +5,10 @@ import org.apache.commons.net.ftp.FTPFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +81,29 @@ public class FtpRemoteClient implements RemoteClient {
             log.error("Failed to rename file. FTP reply: {}", reply);
             throw new IOException("Failed to move file from " + sourcePath + " to " + destinationPath
                     + ". FTP reply: " + reply);
+        }
+    }
+
+    @Override
+    public void deleteFile(String path) throws Exception {
+        boolean success = ftpClient.deleteFile(path);
+        if (!success) {
+            String reply = ftpClient.getReplyString();
+            log.error("Failed to delete file {}. FTP reply: {}", path, reply);
+            throw new IOException("Failed to delete file " + path + ". FTP reply: " + reply);
+        }
+    }
+
+    @Override
+    public void writeTextFile(String path, String contents, Charset charset) throws Exception {
+        byte[] bytes = contents.getBytes(charset);
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes)) {
+            boolean success = ftpClient.storeFile(path, inputStream);
+            if (!success) {
+                String reply = ftpClient.getReplyString();
+                log.error("Failed to store file {}. FTP reply: {}", path, reply);
+                throw new IOException("Failed to write file " + path + ". FTP reply: " + reply);
+            }
         }
     }
 

--- a/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceConnector.java
+++ b/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceConnector.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class FtpSourceConnector extends SourceConnector {
 
-        public static final String VERSION = "1.0.0";
+        public static final String VERSION = "1.0.1";
 
         public static final String FTP_PROTOCOL = "ftp.protocol";
         public static final String FTP_HOST = "ftp.host";

--- a/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/RemoteClient.java
+++ b/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/RemoteClient.java
@@ -1,6 +1,7 @@
 package br.com.datastreambrasil.kafka.connector.ftp;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.List;
 
 public interface RemoteClient {
@@ -11,6 +12,10 @@ public interface RemoteClient {
     InputStream retrieveFileStream(String filePath) throws Exception;
 
     void moveFile(String sourcePath, String destinationPath) throws Exception;
+
+    void deleteFile(String path) throws Exception;
+
+    void writeTextFile(String path, String contents, Charset charset) throws Exception;
 
     void disconnect();
 }

--- a/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/SftpRemoteClient.java
+++ b/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/SftpRemoteClient.java
@@ -9,6 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +74,19 @@ public class SftpRemoteClient implements RemoteClient {
     @Override
     public void moveFile(String sourcePath, String destinationPath) throws Exception {
         sftp.rename(sourcePath, destinationPath);
+    }
+
+    @Override
+    public void deleteFile(String path) throws Exception {
+        sftp.remove(path);
+    }
+
+    @Override
+    public void writeTextFile(String path, String contents, Charset charset) throws Exception {
+        byte[] data = contents.getBytes(charset);
+        try (OutputStream out = sftp.write(path)) {
+            out.write(data);
+        }
     }
 
     @Override

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -1,3 +1,5 @@
 name=ftp-source-connector
 version=1.0.1
 description=Kafka Connect Source Connector for files over FTP/SFTP
+connector.class=br.com.datastreambrasil.kafka.connector.ftp.FtpSourceConnector
+type=source


### PR DESCRIPTION
## Summary
- extend the RemoteClient abstraction with delete and text file write support and implement both behaviors for FTP and SFTP
- update FtpSourceTask to replace archiving with staged file deletion and timestamped summary report creation that records processed line counts
- refresh unit tests and documentation to reflect the new summary workflow
- ensure the connector continues to build and load on Java 11 runtimes by aligning the bytecode target, metadata and docs, including avoiding Java 16-specific language features

## Testing
- `mvn -q test` *(fails: 403 retrieving org.jacoco:jacoco-maven-plugin:0.8.10 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f8ecc0c883309b0fee69945aa334