### PR TITLE
Fix connector version test to match connector constant

### DIFF
--- a/src/test/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceConnectorTest.java
+++ b/src/test/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceConnectorTest.java
@@ -52,7 +52,7 @@ class FtpSourceConnectorTest {
 
     @Test
     void testVersion() {
-        assertEquals("1.0.0", connector.version());
+        assertEquals(FtpSourceConnector.VERSION, connector.version());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update the version assertion in `FtpSourceConnectorTest` to compare against the connector's declared version constant

## Testing
- mvn -q -DskipITs clean test *(fails: unable to resolve org.jacoco:jacoco-maven-plugin due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fbb4a80c83309d6dbf5fd16ef22f