### PR TITLE
Add Java public-type vs filename checker and README troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ Each file is read line by line, and each line is sent as an independent Kafka re
 
 ---
 
+## Troubleshooting
+
+### Compilation error: `class FtpSourceTask is public, should be declared in a file named FtpSourceTask.java`
+
+If you created custom classes such as `FtpSourceTaskEnhanced.java` or `FtpSourceConnectorEnhanced.java`, ensure that each `public class` name exactly matches its file name.
+
+Examples:
+
+- `FtpSourceTaskEnhanced.java` must declare `public class FtpSourceTaskEnhanced`.
+- `FtpSourceTask.java` must declare `public class FtpSourceTask`.
+
+If a connector class references `FtpSourceTaskEnhanced`, then that class must exist with the exact package and name.
+
+Quick recovery:
+
+1. Rename classes/files to match exactly.
+2. Remove stale generated files from IDE caches.
+3. Run `./scripts/check-java-public-type-names.sh` to identify file/class mismatches quickly.
+4. Run `mvn clean compile` again.
+
+---
+
 ## Configuration Example
 
 ```json

--- a/scripts/check-java-public-type-names.sh
+++ b/scripts/check-java-public-type-names.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${1:-src/main/java}"
+
+if [[ ! -d "$ROOT_DIR" ]]; then
+  echo "Directory not found: $ROOT_DIR" >&2
+  exit 2
+fi
+
+status=0
+
+while IFS= read -r -d '' file; do
+  base_name="$(basename "$file" .java)"
+
+  # Finds first public top-level type declaration.
+  declared_name="$({
+    sed -E 's://.*$::' "$file" |
+      tr -d '\r' |
+      awk '
+        match($0, /^[[:space:]]*public[[:space:]]+(class|interface|enum|record)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)/, m) {
+          print m[2];
+          exit
+        }
+      '
+  } || true)"
+
+  if [[ -n "$declared_name" && "$declared_name" != "$base_name" ]]; then
+    echo "Mismatch: $file declares public type '$declared_name' but filename is '$base_name.java'"
+    status=1
+  fi
+done < <(find "$ROOT_DIR" -type f -name '*.java' -print0)
+
+if [[ "$status" -eq 0 ]]; then
+  echo "OK: no public type/file name mismatches found in $ROOT_DIR"
+else
+  echo "ERROR: found public type/file name mismatches"
+fi
+
+exit "$status"


### PR DESCRIPTION
### Motivation

- Provide a fast, deterministic diagnostic for a common compilation failure where a top-level `public` type name does not match its `.java` filename, which was causing the reported Maven compile error.

### Description

- Add `scripts/check-java-public-type-names.sh`, a small shell script that scans `src/main/java` (or a provided directory) and reports any `public class`/`interface`/`enum`/`record` whose declared name differs from its filename.
- Update `README.md` Troubleshooting to document the error and recommend running `./scripts/check-java-public-type-names.sh` before `mvn clean compile` as a quick recovery step.

### Testing

- Ran `./scripts/check-java-public-type-names.sh` against the repository and it completed successfully with `OK: no public type/file name mismatches found in src/main/java`.
- Ran `mvn test -q` which failed to complete due to external plugin resolution failing with HTTP 403 for `org.jacoco:jacoco-maven-plugin:0.8.10`, which is an environment/external repository issue and unrelated to the script or README changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5885f7d083308ca3d5b4b474d230)