### PR TITLE
Fix Java filename checker portability for mawk/Ubuntu environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ Each file is read line by line, and each line is sent as an independent Kafka re
 
 ---
 
+## Troubleshooting
+
+### Compilation error: `class FtpSourceTask is public, should be declared in a file named FtpSourceTask.java`
+
+If you created custom classes such as `FtpSourceTaskEnhanced.java` or `FtpSourceConnectorEnhanced.java`, ensure that each `public class` name exactly matches its file name.
+
+Examples:
+
+- `FtpSourceTaskEnhanced.java` must declare `public class FtpSourceTaskEnhanced`.
+- `FtpSourceTask.java` must declare `public class FtpSourceTask`.
+
+If a connector class references `FtpSourceTaskEnhanced`, then that class must exist with the exact package and name.
+
+Quick recovery:
+
+1. Rename classes/files to match exactly.
+2. Remove stale generated files from IDE caches.
+3. Run `./scripts/check-java-public-type-names.sh` (from project root) to identify file/class mismatches quickly.
+   - Optional: pass a directory, e.g. `./scripts/check-java-public-type-names.sh src/main/java`.
+4. Run `mvn clean compile` again.
+
+---
+
 ## Configuration Example
 
 ```json

--- a/scripts/check-java-public-type-names.sh
+++ b/scripts/check-java-public-type-names.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${1:-src/main/java}"
+
+if [[ ! -d "$ROOT_DIR" ]]; then
+  echo "Directory not found: $ROOT_DIR" >&2
+  exit 2
+fi
+
+status=0
+
+while IFS= read -r -d '' file; do
+  base_name="$(basename "$file" .java)"
+
+  # Finds first public top-level type declaration in a POSIX-tool-friendly way.
+  declared_name="$({
+    sed -E 's://.*$::' "$file" |
+      tr -d '\r' |
+      grep -Eom1 '^[[:space:]]*public[[:space:]]+(class|interface|enum|record)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' |
+      sed -E 's/^[[:space:]]*public[[:space:]]+(class|interface|enum|record)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*$/\2/'
+  } || true)"
+
+  if [[ -n "$declared_name" && "$declared_name" != "$base_name" ]]; then
+    echo "Mismatch: $file declares public type '$declared_name' but filename is '$base_name.java'"
+    status=1
+  fi
+done < <(find "$ROOT_DIR" -type f -name '*.java' -print0)
+
+if [[ "$status" -eq 0 ]]; then
+  echo "OK: no public type/file name mismatches found in $ROOT_DIR"
+else
+  echo "ERROR: found public type/file name mismatches"
+fi
+
+exit "$status"


### PR DESCRIPTION
### Motivation
- The previous checker used `awk` features (`match(..., ..., array)`) not supported by common non-gawk implementations (e.g., `mawk`), producing repeated `awk: syntax error` noise while still printing `OK`, which could hide real mismatches.  
- Make the checker robust across typical Linux defaults and clarify usage in troubleshooting to reduce developer friction when `mvn clean compile` fails with a public type/filename mismatch.

### Description
- Replace the fragile `awk`-based declaration extraction with a POSIX-tool-friendly pipeline using `sed`/`tr`/`grep`/`sed` to capture the first top-level `public` type name.  
- Add `scripts/check-java-public-type-names.sh` implementing the portable checker that accepts an optional directory argument (default `src/main/java`) and exits non-zero on mismatches.  
- Update `README.md` Troubleshooting to instruct running `./scripts/check-java-public-type-names.sh` from the project root and note the optional directory argument.

### Testing
- Ran `./scripts/check-java-public-type-names.sh` on the repository and it completed successfully (no mismatches reported).  
- Created a temporary file with a mismatched public type and ran the script to confirm it prints a `Mismatch` and exits with non-zero status.  
- Ran `mvn test -q` which failed due to external dependency resolution (`org.jacoco:jacoco-maven-plugin:0.8.10` returned HTTP 403), which is an external environment issue unrelated to the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5885f7d083308ca3d5b4b474d230)